### PR TITLE
Allow iat to be equal current time

### DIFF
--- a/lib/jwt/claim/iat.ex
+++ b/lib/jwt/claim/iat.ex
@@ -19,7 +19,7 @@ defmodule JWT.Claim.Iat do
   until the specified UTC date/time; non-integer values may be used
   """
   def reject?(numeric_date, _) when is_number(numeric_date) do
-    numeric_date >= DateTime.to_unix(DateTime.utc_now())
+    numeric_date > DateTime.to_unix(DateTime.utc_now())
   end
 
   def reject?(_, _), do: true


### PR DESCRIPTION
For cases when the time it takes from generating the JWT to validating it is less than 1 second.